### PR TITLE
Fix: Make CI ignore warnings

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,6 +23,6 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build --no-restore --property WarningLevel=1
     - name: Test
       run: dotnet test --no-build --verbosity normal


### PR DESCRIPTION
- Make `dotnet build` ignore warnings, only report errors when there is any